### PR TITLE
[#8] Add ways to change the amount of context shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ Error:
 
 !["example serde_yaml output"](resources/example_output/serde_yaml.png)
 
+The crate will also shorten long lines if necessary (from
+[examples/serde_yaml.rs](examples/serde_yaml.rs)):
+```
+Error:
+   | values:
+   |   - 'first'
+   |   - 'second'
+ 4 |   - third: Lorem ipsum dolor sit amet, consectetur adipiscing...
+   |           ^ values[2]: invalid type: map, expected a string at line 4 column 10
+```
+
+!["example serde_yaml output"](resources/example_output/serde_yaml_long.png)
+
+The amount of context for lines and characters can be controlled globally and
+per error. See documentation for how to do that. Adding context and shortening
+the lines can also be disabled.
+
 ## Crate Features
 
 ### `serde_yaml`

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -458,6 +458,7 @@ mod context_long_line {
 mod custom {
     use pretty_assertions::assert_eq;
 
+    /// Test with a short line
     #[test]
     fn short_line() {
         super::init();
@@ -488,6 +489,8 @@ mod custom {
         assert_eq!(expected, got);
     }
 
+    /// Test with a short line where we set the amount of context lines to 0 to
+    /// show no context lines
     #[test]
     fn short_line_change_no_line_context() {
         super::init();
@@ -517,6 +520,37 @@ mod custom {
         assert_eq!(expected, got);
     }
 
+    /// Test with a short line where context is disabled
+    #[test]
+    fn short_line_disable_context() {
+        super::init();
+
+        let config_str =
+            "this is just a config file\nthe error is here: !\nanother line in the config";
+        let line = 2;
+        let column = 19;
+        let err = format!("Found an error at line {}, column {}", line, column);
+
+        let mut expected = String::from("\n");
+        expected.push_str(" 2 | the error is here: !\n");
+        expected.push_str("   |                    ^ Found an error at line 2, column 19\n");
+
+        let got = format!(
+            "{}",
+            super::SerdeError::new(
+                config_str.to_string(),
+                (err.into(), Some(line), Some(column))
+            )
+            .set_contextualize(false)
+        );
+
+        println!("got:\n{}", got);
+        println!("expected:\n{}", expected);
+
+        assert_eq!(expected, got);
+    }
+
+    /// Test with long lines
     #[test]
     fn long_line() {
         super::init();
@@ -551,6 +585,7 @@ mod custom {
         assert_eq!(expected, got);
     }
 
+    /// Test with long lines but less context characters
     #[test]
     fn long_line_change_context_characters() {
         super::init();


### PR DESCRIPTION
* Add functions for `SerdeError` to change the amount of context shown for
lines and characters.
* Add global function to change the default amount of context shown for
lines and characters.

Fixes #8.